### PR TITLE
HOCS-680 - Correct link in notify emails

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/notify/client/infoclient/UserDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/client/infoclient/UserDto.java
@@ -19,7 +19,7 @@ public class UserDto {
     @JsonProperty("lastName")
     private String lastName;
 
-    @JsonProperty("notify")
+    @JsonProperty("email")
     private String email;
 
 }


### PR DESCRIPTION
fixing incorrect annotation causing the email field to always be null