### PR TITLE
HOCS-1057 Match upstream ACP settings

### DIFF
--- a/src/main/resources/application-sqs.properties
+++ b/src/main/resources/application-sqs.properties
@@ -1,3 +1,3 @@
 notify.redrive.policy={"maxReceiveCount": "${notify.queue.maximumRedeliveries}", "deadLetterTargetArn":"arn:aws:sqs:${aws.sqs.region}:${aws.account.id}:${notify.queue.dlq.name}"}
-notify.queue=aws-sqs://arn:aws:sqs:${aws.sqs.region}:${aws.account.id}:${notify.queue.name}?amazonSQSClient=#sqsClient&messageAttributeNames=All&redrivePolicy=${notify.redrive.policy}&waitTimeSeconds=0&defaultVisibilityTimeout=30&visibilityTimeout=60&extendMessageVisibility=true&messageRetentionPeriod=300
+notify.queue=aws-sqs://arn:aws:sqs:${aws.sqs.region}:${aws.account.id}:${notify.queue.name}?amazonSQSClient=#sqsClient&messageAttributeNames=All&redrivePolicy=${notify.redrive.policy}&waitTimeSeconds=0&defaultVisibilityTimeout=30&visibilityTimeout=60&extendMessageVisibility=true&messageRetentionPeriod=345600
 notify.queue.dlq=aws-sqs://arn:aws:sqs:${aws.sqs.region}:${aws.account.id}:${notify.queue.dlq.name}?amazonSQSClient=#sqsClient&messageAttributeNames=All

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,6 @@ hocs.basicauth=UNSET
 hocs.url=http://localhost:8080
 notify.apiKey=aaaaaaaaaa-11111111-1111-1111-1111-111111111111-11111111-1111-1111-aaaa-aaaaaaaaaaaa
 
-notify.queue.maximumRedeliveries=2
+notify.queue.maximumRedeliveries=10
 notify.queue.redeliveryDelay=10000
 notify.queue.backOffMultiplier=2


### PR DESCRIPTION
This commit does the following:
- Increase messageRetentionPeriod to 4d
- Increase redrive policy to 10

This is in line with ACP global defaults.
At the moment the existing settings are ineffective, as ACP's global
Terraform scripts will overwrite these settings (and vice versa).