### PR TITLE
Change port number

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ info.app.name=${name:hocs-notify-service}
 info.app.fullname=Hocs Notify Service
 info.app.version=${version:0.0.1}
 spring.main.banner-mode=off
-server.port=8091
+server.port=8092
 
 hocs.info-service=http://localhost:8085
 hocs.basicauth=UNSET


### PR DESCRIPTION
At present we have a conflict with the hocs-workflow service over point 8091. For ease a change to the notify server port to 8092, this removes the conflict.