### PR TITLE
Feature/hocs 3327 add retryable to resthelper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 		exclude(module: 'spring-boot-starter-tomcat')
 	}
 	implementation('org.springframework.boot:spring-boot-starter-undertow')
+	implementation('org.springframework.retry:spring-retry')
 	implementation('net.logstash.logback:logstash-logback-encoder:5.3')
 	implementation('uk.gov.service.notify:notifications-java-client:3.12.0-RELEASE')
 	implementation('com.amazonaws:aws-java-sdk:1.11.569')

--- a/src/main/java/uk/gov/digital/ho/hocs/notify/HocsNotifyServiceApplication.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/HocsNotifyServiceApplication.java
@@ -16,7 +16,7 @@ public class HocsNotifyServiceApplication {
 
 	@PreDestroy
 	public void stop() {
-		log.info("hocs-notify stopping gracefully");
+		log.info("Stopping gracefully");
 	}
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/notify/application/RestHelper.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/application/RestHelper.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.hocs.notify.application;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
@@ -32,12 +33,14 @@ public class RestHelper {
         this.requestData = requestData;
     }
 
+    @Retryable
     public <R> R get(String serviceBaseURL, String url, Class<R> responseType) {
         log.info("RestHelper making Get request to {}{}", serviceBaseURL, url, value(EVENT, REST_HELPER_GET));
         ResponseEntity<R> response = restTemplate.exchange(String.format("%s%s", serviceBaseURL, url), HttpMethod.GET, new HttpEntity<>(null, createAuthHeaders()), responseType);
         return response.getBody();
     }
 
+    @Retryable
     public <R> R get(String serviceBaseURL, String url, ParameterizedTypeReference<R> responseType) {
         log.info("RestHelper making Get request to {}{}", serviceBaseURL, url, value(EVENT, REST_HELPER_GET));
         ResponseEntity<R> response = restTemplate.exchange(String.format("%s%s", serviceBaseURL, url), HttpMethod.GET, new HttpEntity<>(null, createAuthHeaders()), responseType);


### PR DESCRIPTION
- Add @Retryable to RestHelper client calls
    - Using default values.
- Remove app name from logging.
