### PR TITLE
Change Dependabot `ignore` dependency name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,5 @@ updates:
     reviewers:
       - "UKHomeOffice/hocs-core"
     ignore:
-      - dependency-name: "aws-java-sdk"
+      - dependency-name: "com.amazonaws:aws-java-sdk"
         update-types: [ "version-update:semver-patch" ]


### PR DESCRIPTION
For Java dependencies Dependabot requires both the `groupId` and the
`artifactId` to ignore. This change adds the `groupId` to allow for the
ignore to work as intended.