### PR TITLE
HOCS-1746 Use quay.io mirror

### DIFF
--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - name: registry-credentials
       initContainers:
         - name: truststore
-          image: quay.io/ukhomeofficedigital/cfssl-sidekick-jks:v0.0.9
+          image: quay.digital.homeoffice.gov.uk/ukhomeofficedigital/cfssl-sidekick-jks:v0.0.9
           securityContext:
             runAsNonRoot: true
             capabilities:
@@ -64,7 +64,7 @@ spec:
 
       containers:
         - name: certs
-          image: quay.io/ukhomeofficedigital/cfssl-sidekick:v0.0.9
+          image: quay.digital.homeoffice.gov.uk/ukhomeofficedigital/cfssl-sidekick:v0.0.9
           securityContext:
             runAsNonRoot: true
             capabilities:
@@ -96,7 +96,7 @@ spec:
               cpu: 100m
 
         - name: proxy
-          image: quay.io/ukhomeofficedigital/nginx-proxy:v4.2.0
+          image: quay.digital.homeoffice.gov.uk/ukhomeofficedigital/nginx-proxy:v4.2.0
           securityContext:
             runAsNonRoot: true
             capabilities:
@@ -146,7 +146,7 @@ spec:
               cpu: 100m
 
         - name: hocs-notify
-          image: quay.io/ukhomeofficedigital/hocs-notify:{{.VERSION}}
+          image: quay.digital.homeoffice.gov.uk/ukhomeofficedigital/hocs-notify:{{.VERSION}}
           securityContext:
             runAsNonRoot: true
             capabilities:


### PR DESCRIPTION
ACP now has a proxy for Quay.io via the ACP-hosted Artifactory.
This commit replaces references for "quay.io" to the new equivalent,
"quay.digital.homeoffice.gov.uk".

Images that have been pulled at least once will therefore be able to be
pulled even if Quay.io is down. However, this simply moves the
dependency: if Artifactory goes down, so will our images; it's not a
replacement for general image-caching best practices.