### PR TITLE
HOCS-3950: Retrieve the headers from sqs message and pass to RequestData

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/notify/api/NotifyService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/api/NotifyService.java
@@ -82,13 +82,9 @@ public class NotifyService {
             if (newUserUUID != null) {
                 if (currentUserUUID != null && !newUserUUID.equals(currentUserUUID)) {
                     sendUnAllocateUserEmail(caseUUID, stageUUID, currentUserUUID, caseReference);
-                    if (!newUserUUID.equals(requestData.userIdUUID())) {
-                        sendAllocateUserEmail(caseUUID, stageUUID, newUserUUID, caseReference);
-                    }
-                } else {
-                    if (!newUserUUID.equals(requestData.userIdUUID())) {
-                        sendAllocateUserEmail(caseUUID, stageUUID, newUserUUID, caseReference);
-                    }
+                }
+                if (!newUserUUID.toString().equals(requestData.userId())) {
+                    sendAllocateUserEmail(caseUUID, stageUUID, newUserUUID, caseReference);
                 }
             } else if (currentUserUUID != null) {
                 sendUnAllocateUserEmail(caseUUID, stageUUID, currentUserUUID, caseReference);

--- a/src/main/java/uk/gov/digital/ho/hocs/notify/application/RequestData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/application/RequestData.java
@@ -35,6 +35,10 @@ public class RequestData implements HandlerInterceptor {
         }
     }
 
+    public void clear(){
+        MDC.clear();
+    }
+
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         MDC.clear();
@@ -57,12 +61,22 @@ public class RequestData implements HandlerInterceptor {
         MDC.clear();
     }
 
-    public void clear(){
-        MDC.clear();
+    private String initialiseCorrelationId(HttpServletRequest request) {
+        String correlationId = request.getHeader(CORRELATION_ID_HEADER);
+        return !isNullOrEmpty(correlationId) ? correlationId : UUID.randomUUID().toString();
+    }
+
+    private String initialiseGroups(HttpServletRequest request) {
+        String groups = request.getHeader(GROUP_HEADER);
+        return !isNullOrEmpty(groups) ? groups : "/QU5PTllNT1VTCg==";
     }
 
     public String correlationId() {
         return MDC.get(CORRELATION_ID_HEADER);
+    }
+
+    public String userId() {
+        return MDC.get(USER_ID_HEADER);
     }
 
     public UUID userIdUUID() {
@@ -75,20 +89,6 @@ public class RequestData implements HandlerInterceptor {
 
     public String groups() {
         return MDC.get(GROUP_HEADER);
-    }
-
-    private String userId() {
-        return MDC.get(USER_ID_HEADER);
-    }
-
-    private String initialiseCorrelationId(HttpServletRequest request) {
-        String correlationId = request.getHeader(CORRELATION_ID_HEADER);
-        return !isNullOrEmpty(correlationId) ? correlationId : UUID.randomUUID().toString();
-    }
-
-    private String initialiseGroups(HttpServletRequest request) {
-        String groups = request.getHeader(GROUP_HEADER);
-        return !isNullOrEmpty(groups) ? groups : "/QU5PTllNT1VTCg==";
     }
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/notify/application/RequestData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/application/RequestData.java
@@ -7,6 +7,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
 import java.util.UUID;
 
 @Component
@@ -20,6 +21,20 @@ public class RequestData implements HandlerInterceptor {
 
     private static boolean isNullOrEmpty(String value) {
         return value == null || value.equals("");
+    }
+
+    public void parseMessageHeaders(Map<String,String> headers) {
+        if(headers.containsKey(CORRELATION_ID_HEADER)) {
+            MDC.put(CORRELATION_ID_HEADER, headers.get(CORRELATION_ID_HEADER));
+        }
+
+        if(headers.containsKey(USER_ID_HEADER)) {
+            MDC.put(USER_ID_HEADER, headers.get(USER_ID_HEADER));
+        }
+
+        if(headers.containsKey(GROUP_HEADER)) {
+            MDC.put(GROUP_HEADER, headers.get(GROUP_HEADER));
+        }
     }
 
     @Override

--- a/src/main/java/uk/gov/digital/ho/hocs/notify/application/RequestData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/application/RequestData.java
@@ -41,7 +41,6 @@ public class RequestData implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         MDC.clear();
         MDC.put(CORRELATION_ID_HEADER, initialiseCorrelationId(request));
-        MDC.put(USER_ID_HEADER, initialiseUserId(request));
         MDC.put(GROUP_HEADER, initialiseGroups(request));
 
         return true;
@@ -64,11 +63,6 @@ public class RequestData implements HandlerInterceptor {
         return !isNullOrEmpty(correlationId) ? correlationId : UUID.randomUUID().toString();
     }
 
-    private String initialiseUserId(HttpServletRequest request) {
-        String userId = request.getHeader(USER_ID_HEADER);
-        return !isNullOrEmpty(userId) ? userId : ANONYMOUS;
-    }
-
     private String initialiseGroups(HttpServletRequest request) {
         String groups = request.getHeader(GROUP_HEADER);
         return !isNullOrEmpty(groups) ? groups : "/QU5PTllNT1VTCg==";
@@ -78,16 +72,20 @@ public class RequestData implements HandlerInterceptor {
         return MDC.get(CORRELATION_ID_HEADER);
     }
 
-    public String userId() {
-        return MDC.get(USER_ID_HEADER);
-    }
-
     public UUID userIdUUID() {
-        return UUID.fromString(MDC.get(USER_ID_HEADER));
+        String userId = MDC.get(USER_ID_HEADER);
+        if(userId == null) {
+            return null;
+        }
+        return UUID.fromString(userId);
     }
 
     public String groups() {
         return MDC.get(GROUP_HEADER);
+    }
+
+    private String userId() {
+        return MDC.get(USER_ID_HEADER);
     }
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/notify/application/RequestData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/application/RequestData.java
@@ -17,8 +17,6 @@ public class RequestData implements HandlerInterceptor {
     static final String USER_ID_HEADER = "X-Auth-UserId";
     static final String GROUP_HEADER = "X-Auth-Groups";
 
-    private static final String ANONYMOUS = "anonymous";
-
     private static boolean isNullOrEmpty(String value) {
         return value == null || value.equals("");
     }
@@ -41,6 +39,7 @@ public class RequestData implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         MDC.clear();
         MDC.put(CORRELATION_ID_HEADER, initialiseCorrelationId(request));
+        MDC.put(USER_ID_HEADER, request.getHeader(USER_ID_HEADER));
         MDC.put(GROUP_HEADER, initialiseGroups(request));
 
         return true;
@@ -58,14 +57,8 @@ public class RequestData implements HandlerInterceptor {
         MDC.clear();
     }
 
-    private String initialiseCorrelationId(HttpServletRequest request) {
-        String correlationId = request.getHeader(CORRELATION_ID_HEADER);
-        return !isNullOrEmpty(correlationId) ? correlationId : UUID.randomUUID().toString();
-    }
-
-    private String initialiseGroups(HttpServletRequest request) {
-        String groups = request.getHeader(GROUP_HEADER);
-        return !isNullOrEmpty(groups) ? groups : "/QU5PTllNT1VTCg==";
+    public void clear(){
+        MDC.clear();
     }
 
     public String correlationId() {
@@ -86,6 +79,16 @@ public class RequestData implements HandlerInterceptor {
 
     private String userId() {
         return MDC.get(USER_ID_HEADER);
+    }
+
+    private String initialiseCorrelationId(HttpServletRequest request) {
+        String correlationId = request.getHeader(CORRELATION_ID_HEADER);
+        return !isNullOrEmpty(correlationId) ? correlationId : UUID.randomUUID().toString();
+    }
+
+    private String initialiseGroups(HttpServletRequest request) {
+        String groups = request.getHeader(GROUP_HEADER);
+        return !isNullOrEmpty(groups) ? groups : "/QU5PTllNT1VTCg==";
     }
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/notify/application/RequestData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/application/RequestData.java
@@ -79,14 +79,6 @@ public class RequestData implements HandlerInterceptor {
         return MDC.get(USER_ID_HEADER);
     }
 
-    public UUID userIdUUID() {
-        String userId = MDC.get(USER_ID_HEADER);
-        if(userId == null) {
-            return null;
-        }
-        return UUID.fromString(userId);
-    }
-
     public String groups() {
         return MDC.get(GROUP_HEADER);
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/notify/application/RestHelper.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/application/RestHelper.java
@@ -49,7 +49,7 @@ public class RestHelper {
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.add(AUTHORIZATION, getBasicAuth());
         headers.add(RequestData.GROUP_HEADER, requestData.groups());
-        headers.add(RequestData.USER_ID_HEADER, requestData.userIdUUID().toString());
+        headers.add(RequestData.USER_ID_HEADER, requestData.userId());
         headers.add(RequestData.CORRELATION_ID_HEADER, requestData.correlationId());
         return headers;
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/notify/application/RestHelper.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/application/RestHelper.java
@@ -49,7 +49,7 @@ public class RestHelper {
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.add(AUTHORIZATION, getBasicAuth());
         headers.add(RequestData.GROUP_HEADER, requestData.groups());
-        headers.add(RequestData.USER_ID_HEADER, requestData.userId());
+        headers.add(RequestData.USER_ID_HEADER, requestData.userIdUUID().toString());
         headers.add(RequestData.CORRELATION_ID_HEADER, requestData.correlationId());
         return headers;
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/notify/aws/listeners/NotifyListener.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/aws/listeners/NotifyListener.java
@@ -4,25 +4,35 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.cloud.aws.messaging.listener.SqsMessageDeletionPolicy;
 import org.springframework.cloud.aws.messaging.listener.annotation.SqsListener;
+import org.springframework.messaging.handler.annotation.Headers;
 import org.springframework.stereotype.Service;
 import uk.gov.digital.ho.hocs.notify.api.dto.NotifyCommand;
+import uk.gov.digital.ho.hocs.notify.application.RequestData;
 import uk.gov.digital.ho.hocs.notify.domain.NotifyDomain;
+
+import java.util.Map;
 
 @Service
 public class NotifyListener {
 
     private final ObjectMapper objectMapper;
     private final NotifyDomain notifyDomain;
+    private final RequestData requestData;
 
     public NotifyListener(ObjectMapper objectMapper,
-                          NotifyDomain notifyDomain) {
+                          NotifyDomain notifyDomain,
+                          RequestData requestData) {
         this.objectMapper = objectMapper;
         this.notifyDomain = notifyDomain;
+        this.requestData = requestData;
     }
 
     @SqsListener(value = "${aws.sqs.notify.url}", deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
-    public void onNotifyEvent(String message) throws JsonProcessingException {
-
+    public void onNotifyEvent(
+            String message,
+            @Headers Map<String,String> headers
+    ) throws JsonProcessingException {
+        requestData.parseMessageHeaders(headers);
         NotifyCommand command = objectMapper.readValue(message, NotifyCommand.class);
         notifyDomain.executeCommand(command);
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/notify/aws/listeners/NotifyListener.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/aws/listeners/NotifyListener.java
@@ -35,6 +35,7 @@ public class NotifyListener {
         requestData.parseMessageHeaders(headers);
         NotifyCommand command = objectMapper.readValue(message, NotifyCommand.class);
         notifyDomain.executeCommand(command);
+        requestData.clear();
     }
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/notify/aws/listeners/NotifyListener.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/aws/listeners/NotifyListener.java
@@ -32,10 +32,13 @@ public class NotifyListener {
             String message,
             @Headers Map<String,String> headers
     ) throws JsonProcessingException {
-        requestData.parseMessageHeaders(headers);
-        NotifyCommand command = objectMapper.readValue(message, NotifyCommand.class);
-        notifyDomain.executeCommand(command);
-        requestData.clear();
+        try {
+            requestData.parseMessageHeaders(headers);
+            NotifyCommand command = objectMapper.readValue(message, NotifyCommand.class);
+            notifyDomain.executeCommand(command);
+        } finally {
+            requestData.clear();
+        }
     }
 
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/notify/RequestDataTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/notify/RequestDataTest.java
@@ -1,6 +1,6 @@
 package uk.gov.digital.ho.hocs.notify;
 
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -27,11 +27,11 @@ public class RequestDataTest
     @Mock
     private Object mockHandler;
 
-    private RequestData requestData;
+    private RequestData requestData = new RequestData();
 
-    @BeforeEach
-    public void setup() {
-        requestData = new RequestData();
+    @AfterEach
+    public void after() {
+        requestData.clear();
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/hocs/notify/RequestDataTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/notify/RequestDataTest.java
@@ -58,7 +58,7 @@ public class RequestDataTest
 
         requestData.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
 
-        assertThat(requestData.userIdUUID()).isEqualTo(userUUID);
+        assertThat(requestData.userId()).isEqualTo(userUUID.toString());
     }
 
     @Test
@@ -70,7 +70,7 @@ public class RequestDataTest
 
         requestData.parseMessageHeaders(headers);
 
-        assertThat(requestData.userIdUUID()).isEqualTo(userId);
+        assertThat(requestData.userId()).isEqualTo(userId.toString());
     }
 
     @Test
@@ -100,7 +100,6 @@ public class RequestDataTest
 
     @Test
     public void shouldGetUserUUIDNull() {
-        // This used to throw a NPE
-        assertThat(requestData.userIdUUID()).isNull();
+        assertThat(requestData.userId()).isNull();
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/notify/api/NotifyServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/notify/api/NotifyServiceTest.java
@@ -81,11 +81,11 @@ class NotifyServiceTest {
         UUID currentUserUUID = null;
         UUID newUserUUID = UUID.fromString("11111111-0000-0000-0000-000000000000");
 
-        when(requestData.userIdUUID()).thenReturn(UUID.fromString("11111111-0000-0000-0000-000000000000"));
+        when(requestData.userId()).thenReturn(newUserUUID.toString());
 
         notifyService.sendUserAssignChangeEmail(caseUUID, stageUUID, caseRef, currentUserUUID, newUserUUID);
 
-        verify(requestData).userIdUUID();
+        verify(requestData).userId();
 
         verifyNoInteractions(infoClient);
         verifyNoInteractions(notifyClient);
@@ -104,11 +104,11 @@ class NotifyServiceTest {
         personalisation.put("user", "name");
 
         when(infoClient.getUser(newUserUUID)).thenReturn(new UserDto("any", "name", "any", "notify"));
-        when(requestData.userIdUUID()).thenReturn(UUID.fromString("22222222-0000-0000-0000-000000000000"));
+        when(requestData.userId()).thenReturn("22222222-0000-0000-0000-000000000000");
 
         notifyService.sendUserAssignChangeEmail(caseUUID, stageUUID, caseRef, currentUserUUID, newUserUUID);
 
-        verify(requestData).userIdUUID();
+        verify(requestData).userId();
         verify(infoClient).getUser(newUserUUID);
         verify(notifyClient).sendEmail(caseUUID, stageUUID, "notify", personalisation, NotifyType.ALLOCATE_INDIVIDUAL);
 
@@ -167,11 +167,11 @@ class NotifyServiceTest {
         personalisation.put("user", "name");
 
         when(infoClient.getUser(currentUserUUID)).thenReturn(new UserDto("any", "name", "any", "notify"));
-        when(requestData.userIdUUID()).thenReturn(UUID.fromString("11111111-0000-0000-0000-000000000000"));
+        when(requestData.userId()).thenReturn(newUserUUID.toString());
 
         notifyService.sendUserAssignChangeEmail(caseUUID, stageUUID, caseRef, currentUserUUID, newUserUUID);
 
-        verify(requestData).userIdUUID();
+        verify(requestData).userId();
         verify(infoClient).getUser(currentUserUUID);
         verify(notifyClient).sendEmail(caseUUID, stageUUID, "notify", personalisation, NotifyType.UNALLOCATE_INDIVIDUAL);
 
@@ -194,11 +194,11 @@ class NotifyServiceTest {
 
         when(infoClient.getUser(currentUserUUID)).thenReturn(new UserDto("any", "name", "any", "notify"));
         when(infoClient.getUser(newUserUUID)).thenReturn(new UserDto("any", "name", "any", "notify"));
-        when(requestData.userIdUUID()).thenReturn(UUID.fromString("22222222-0000-0000-0000-000000000000"));
+        when(requestData.userId()).thenReturn("22222222-0000-0000-0000-000000000000");
 
         notifyService.sendUserAssignChangeEmail(caseUUID, stageUUID, caseRef, currentUserUUID, newUserUUID);
 
-        verify(requestData).userIdUUID();
+        verify(requestData).userId();
         verify(infoClient).getUser(newUserUUID);
         verify(infoClient).getUser(currentUserUUID);
         verify(notifyClient).sendEmail(caseUUID, stageUUID, "notify", personalisation, NotifyType.ALLOCATE_INDIVIDUAL);

--- a/src/test/java/uk/gov/digital/ho/hocs/notify/aws/listeners/NotifyListenerTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/notify/aws/listeners/NotifyListenerTest.java
@@ -9,10 +9,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.digital.ho.hocs.notify.api.dto.TeamAssignChangeCommand;
+import uk.gov.digital.ho.hocs.notify.application.RequestData;
 import uk.gov.digital.ho.hocs.notify.domain.NotifyDomain;
 import uk.gov.digital.ho.hocs.notify.domain.NotifyType;
 import uk.gov.digital.ho.hocs.notify.domain.exception.EntityCreationException;
 
+import java.util.Map;
 import java.util.UUID;
 
 import static org.mockito.Mockito.verify;
@@ -25,18 +27,20 @@ public class NotifyListenerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-
     @Mock
     private NotifyDomain notifyDomain;
+
+    @Mock
+    private RequestData requestData;
 
     @Test
     public void callsNotifyDomainWithValidNotifyCommand() throws JsonProcessingException {
         TeamAssignChangeCommand teamAssignChangeCommand = new TeamAssignChangeCommand(UUID.randomUUID(), UUID.randomUUID(), "some ref", UUID.randomUUID(), NotifyType.ALLOCATE_PRIVATE_OFFICE.toString());
         String message = objectMapper.writeValueAsString(teamAssignChangeCommand);
 
-        NotifyListener notifyListener = new NotifyListener(objectMapper, notifyDomain);
+        NotifyListener notifyListener = new NotifyListener(objectMapper, notifyDomain, requestData);
 
-        notifyListener.onNotifyEvent(message);
+        notifyListener.onNotifyEvent(message, Map.of());
 
         verify(notifyDomain).executeCommand(teamAssignChangeCommand);
         verifyNoMoreInteractions(notifyDomain);
@@ -44,17 +48,17 @@ public class NotifyListenerTest {
 
     @Test(expected = NullPointerException.class)
     public void callsNotifyDomainWithNullCreateCaseMessage() throws JsonProcessingException {
-        NotifyListener notifyListener = new NotifyListener(objectMapper, notifyDomain);
+        NotifyListener notifyListener = new NotifyListener(objectMapper, notifyDomain, requestData);
 
-        notifyListener.onNotifyEvent(null);
+        notifyListener.onNotifyEvent(null, Map.of());
     }
 
     @Test(expected = EntityCreationException.class)
     public void callsNotifyDomainWithInvalidCreateCaseMessage() throws JsonProcessingException {
         String incorrectMessage = "{test:1}";
-        NotifyListener notifyListener = new NotifyListener(objectMapper, notifyDomain);
+        NotifyListener notifyListener = new NotifyListener(objectMapper, notifyDomain, requestData);
 
-        notifyListener.onNotifyEvent(incorrectMessage);
+        notifyListener.onNotifyEvent(incorrectMessage, Map.of());
     }
 
 }


### PR DESCRIPTION
This PR reads the sqs message headers and populates the RequestData MDC.
Currently we are trying to convert the string 'anonymous' into a UUID and throwing an exception and the emails are not being sent so this behaviour has also been removed and we return null if the userId is null