### PR TITLE
HOCS-5027: add dependabot GitHub Action update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,18 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "⬆️ "
+    pull-request-branch-name:
+      separator: "-"
+    reviewers:
+      - "UKHomeOffice/hocs-core"
+    labels:
+      - "skip-release"
+      - "dependencies"
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:


### PR DESCRIPTION
Add the support for dependabot to handle the updating of GitHub Action
versions within the workflows.