### PR TITLE
HOCS-5561: Remove scripts copy command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ FROM quay.io/ukhomeofficedigital/hocs-base-image
 
 WORKDIR /app
 
-COPY --chown=user_hocs:group_hocs ./scripts/run.sh ./
 COPY --from=builder --chown=user_hocs:group_hocs ./builder/spring-boot-loader/ ./
 COPY --from=builder --chown=user_hocs:group_hocs ./builder/dependencies/ ./
 COPY --from=builder --chown=user_hocs:group_hocs ./builder/application/ ./


### PR DESCRIPTION
Remove the scripts copy command and we no longer use it to start java