### PR TITLE
HOCS-6855: Build changes to include latest spring-cloud-aws-messaging…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,8 @@ dependencies {
 	}
 	implementation 'org.springframework.boot:spring-boot-starter-undertow'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.cloud:spring-cloud-aws-messaging:2.2.6.RELEASE'
+	implementation group: 'io.awspring.cloud', name: 'spring-cloud-aws-messaging', version: '2.4.4'
+	implementation 'org.springframework:spring-messaging:5.3.24'
 
 	implementation 'net.logstash.logback:logstash-logback-encoder:7.3'
 

--- a/src/main/java/uk/gov/digital/ho/hocs/notify/aws/config/LocalStackConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/aws/config/LocalStackConfiguration.java
@@ -6,14 +6,12 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.sqs.AmazonSQSAsync;
 import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cloud.aws.messaging.config.SimpleMessageListenerContainerFactory;
-import org.springframework.cloud.aws.messaging.config.annotation.EnableSqs;
+import io.awspring.cloud.messaging.config.SimpleMessageListenerContainerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 
-@EnableSqs
 @Configuration
 @Profile({"local"})
 public class LocalStackConfiguration {

--- a/src/main/java/uk/gov/digital/ho/hocs/notify/aws/config/SqsConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/aws/config/SqsConfiguration.java
@@ -6,14 +6,12 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.sqs.AmazonSQSAsync;
 import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cloud.aws.messaging.config.SimpleMessageListenerContainerFactory;
-import org.springframework.cloud.aws.messaging.config.annotation.EnableSqs;
+import io.awspring.cloud.messaging.config.SimpleMessageListenerContainerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 
-@EnableSqs
 @Configuration
 @Profile({"sqs"})
 public class SqsConfiguration {

--- a/src/main/java/uk/gov/digital/ho/hocs/notify/aws/listeners/NotifyListener.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/aws/listeners/NotifyListener.java
@@ -2,8 +2,9 @@ package uk.gov.digital.ho.hocs.notify.aws.listeners;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.cloud.aws.messaging.listener.SqsMessageDeletionPolicy;
-import org.springframework.cloud.aws.messaging.listener.annotation.SqsListener;
+import io.awspring.cloud.messaging.config.SimpleMessageListenerContainerFactory;
+import io.awspring.cloud.messaging.listener.annotation.SqsListener;
+import io.awspring.cloud.messaging.listener.SqsMessageDeletionPolicy;
 import org.springframework.messaging.handler.annotation.Headers;
 import org.springframework.stereotype.Service;
 import uk.gov.digital.ho.hocs.notify.api.dto.NotifyCommand;


### PR DESCRIPTION
This PR would help to bring up hocs-notify service and as part of this [PR](https://github.com/UKHomeOffice/hocs-notify/pull/212) we found service run as sqs profile which didn't help the process to come up in DEV.
On further analysis - we found that below issues to get it resolved.
1) Upgraded spring-cloud-aws-messaging to 2.4.4 and found that packaging restructure has happened post 2.3.0 release
2) org.springframework.cloud:spring-cloud-aws-messaging:2.2.6.RELEASE is the last release from Feb 2021 in the same package
3) Added spring-messaging to resolve PayloadArgumentResolver class not found issue when service comes up
4) EnableSqs has been deprecated hence we don't have to include as part of the build (hence removed) - please see this thread for more details - https://stackoverflow.com/questions/72718470/migrate-from-springframework-cloud-aws-messaging-to-awspring-cloud-messaging-ver
5) Tested if service comes up using both {development, local} and sqs profile.
