### PR TITLE
AWS Region should not be hardcoded

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/notify/aws/config/LocalStackConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/aws/config/LocalStackConfiguration.java
@@ -2,6 +2,7 @@ package uk.gov.digital.ho.hocs.notify.aws.config;
 
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -9,16 +10,14 @@ import org.springframework.context.annotation.*;
 
 import java.net.URI;
 
-import static software.amazon.awssdk.regions.Region.EU_WEST_2;
-
 @Configuration
 @Profile({"local"})
 public class LocalStackConfiguration {
 
     @Bean
-    public SqsAsyncClient sqsAsyncClient(@Value("${aws.sqs.config.url}") String awsBaseUrl) {
+    public SqsAsyncClient sqsAsyncClient(@Value("${aws.sqs.config.url}") String awsBaseUrl, @Value("${aws.sqs.region}") Region region) {
         return SqsAsyncClient.builder()
-                .region(EU_WEST_2)
+                .region(region)
                 .credentialsProvider(StaticCredentialsProvider.create(
                         AwsBasicCredentials.create("test", "test")
                 ))

--- a/src/main/java/uk/gov/digital/ho/hocs/notify/aws/config/SqsConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/notify/aws/config/SqsConfiguration.java
@@ -5,9 +5,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.*;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
-
-import static software.amazon.awssdk.regions.Region.EU_WEST_2;
 
 @Configuration
 @Profile({"sqs"})
@@ -15,9 +14,10 @@ public class SqsConfiguration {
 
     @Bean
     public SqsAsyncClient sqsAsyncClient(@Value("${aws.sqs.access.key}") String accessKey,
-                                         @Value("${aws.sqs.secret.key}") String secretKey) {
+                                         @Value("${aws.sqs.secret.key}") String secretKey,
+                                         @Value("${aws.sqs.region}") Region region) {
         return SqsAsyncClient.builder()
-                .region(EU_WEST_2)
+                .region(region)
                 .credentialsProvider(StaticCredentialsProvider.create(
                         AwsBasicCredentials.create(accessKey, secretKey)
                 ))


### PR DESCRIPTION
I missed this in code review, but region should still be loaded from config rather than hardcoding it to eu-west-2